### PR TITLE
Added server components for data-fetching using Prisma

### DIFF
--- a/apps/webshop/src/app/page.tsx
+++ b/apps/webshop/src/app/page.tsx
@@ -1,51 +1,17 @@
 import ProductCard from "@/components/product-card";
-import type { Product } from "@/app/types/types";
+import { getProducts } from "@/lib/actions/products";
 
-const mockProduct: Product = {
-  id: 1,
-  title: "Leaves of Grass",
-  description:
-    "A first edition of Walt Whitman's landmark poetry collection, featuring his revolutionary free verse celebrating nature, humanity, and the American spirit.",
-  price: 4250,
-  discountPercentage: 0,
-  weight: 1.2,
-  warrantyInformation: "Certificate of authenticity included",
-  shippingInformation: "Insured shipping, 5-7 business days",
-  availabilityStatus: "In Stock",
-  category: { id: 1, name: "Poetry" },
-  images: [
-    "https://lh3.googleusercontent.com/aida-public/AB6AXuB8mRudzwP8VJTa54At4LifVArmm9J3Ba845BC4YJci9Qw8---fEp06oSJ0ouN0HybnvCE0t-kOjsXp3S6crVAGijizxfKxmw6Q8s8v8v2A4nVK0rMeqT2BZqOjpS1-0AmJwI8c-m1ud7L9ROQaxueZCckSW-LKCCEU8wa7oaOf_sCpvJdJ-OQoyT4YVxTCiRnYLe4j9FMA_1xwSGZLZyHLuEcd-DFOSHoUi4bqhpD2XiqvpnIRmA2t9ymv5mM8liIPgZ63aukS35x_",
-  ],
-  thumbnail:
-    "https://lh3.googleusercontent.com/aida-public/AB6AXuB8mRudzwP8VJTa54At4LifVArmm9J3Ba845BC4YJci9Qw8---fEp06oSJ0ouN0HybnvCE0t-kOjsXp3S6crVAGijizxfKxmw6Q8s8v8v2A4nVK0rMeqT2BZqOjpS1-0AmJwI8c-m1ud7L9ROQaxueZCckSW-LKCCEU8wa7oaOf_sCpvJdJ-OQoyT4YVxTCiRnYLe4j9FMA_1xwSGZLZyHLuEcd-DFOSHoUi4bqhpD2XiqvpnIRmA2t9ymv5mM8liIPgZ63aukS35x_",
-  tags: ["poetry", "first edition", "american literature"],
-  condition: {
-    id: 1,
-    exterior: "Minor wear on edges",
-    interior: "Clean pages",
-    grade: "Fine",
-  },
-  era: "19th Century",
-  genre: "Poetry",
-  author: {
-    id: 1,
-    name: "Walt Whitman",
-    description: "American poet and journalist",
-  },
-  format: "Hardcover",
-  publisher: {
-    id: 1,
-    name: "James R. Osgood & Co.",
-    description: "Boston publisher",
-  },
-  year: new Date("1855-01-01"),
-  binding: "Leather",
-};
+export default async function Home() {
+	const { data: products } = await getProducts();
 
-export default function Home() {
-  return (
-    <main className="max-w-sm mx-auto p-8">
-      <ProductCard product={mockProduct} />
-    </main>
-  );
+	return (
+		<main className="max-w-7xl mx-auto p-8">
+			<h1 className="font-headline text-3xl mb-8">Catalog</h1>
+			<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
+				{products.map((product) => (
+					<ProductCard key={product.id} product={product} />
+				))}
+			</div>
+		</main>
+	);
 }

--- a/apps/webshop/src/app/types/prisma.ts
+++ b/apps/webshop/src/app/types/prisma.ts
@@ -1,0 +1,30 @@
+import type { Prisma } from "@prisma/client";
+
+export interface PaginationParams {
+	page?: number;
+	pageSize?: number;
+}
+
+export interface ProductFilters extends PaginationParams {
+	categoryId?: number;
+	search?: string;
+	sortBy?: "title" | "price" | "year";
+	sortOrder?: "asc" | "desc";
+}
+
+export interface PaginatedResult<T> {
+	data: T[];
+	total: number;
+	page: number;
+	pageSize: number;
+	totalPages: number;
+}
+
+export type ProductWithRelations = Prisma.ProductGetPayload<{
+	include: {
+		category: true;
+		condition: true;
+		author: true;
+		publisher: true;
+	};
+}>;

--- a/apps/webshop/src/app/types/types.ts
+++ b/apps/webshop/src/app/types/types.ts
@@ -24,7 +24,7 @@ export interface Product {
 
 interface Category {
 	id: number;
-	name?: string;
+	name: string;
 }
 
 interface Condition {

--- a/apps/webshop/src/components/product-card.tsx
+++ b/apps/webshop/src/components/product-card.tsx
@@ -19,7 +19,7 @@ const ProductCard = ({ product }: { product: Product }) => {
 						{product.title}
 					</h3>
 					<span className="font-label text-sm text-primary font-semibold">
-						${product.price.toLocaleString()}
+						{product.price.toLocaleString()} SEK
 					</span>
 				</div>
 				<p className="font-body italic text-secondary">{product.author.name}</p>

--- a/apps/webshop/src/components/product-card.tsx
+++ b/apps/webshop/src/components/product-card.tsx
@@ -1,39 +1,39 @@
 import type { Product } from "@/app/types/types";
 
 const ProductCard = ({ product }: { product: Product }) => {
-  const image = product.thumbnail || product.images[0] || "";
+	const image = product.thumbnail || product.images[0] || "";
 
-  return (
-    <div className="group">
-      <div className="aspect-3/4 overflow-hidden bg-surface-container-low mb-6 relative">
-        <img
-          className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
-          alt={product.title}
-          src={image}
-        />
-        <div className="absolute inset-0 bg-primary/5 opacity-0 group-hover:opacity-100 transition-opacity"></div>
-      </div>
-      <div className="space-y-2">
-        <div className="flex justify-between items-start">
-          <h3 className="font-headline text-xl text-on-surface leading-tight group-hover:text-primary transition-colors">
-            {product.title}
-          </h3>
-          <span className="font-label text-sm text-primary font-semibold">
-            ${product.price.toLocaleString()}
-          </span>
-        </div>
-        <p className="font-body italic text-secondary">{product.author.name}</p>
-        <div className="flex items-center gap-3 pt-2">
-          <span className="font-label text-[10px] uppercase tracking-widest px-2 py-1 bg-surface-container-highest text-secondary">
-            {new Date(product.year).getFullYear()}
-          </span>
-          <span className="font-label text-[10px] uppercase tracking-widest px-2 py-1 bg-surface-container-highest text-secondary">
-            {product.condition.grade}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
+	return (
+		<div className="group">
+			<div className="aspect-3/4 overflow-hidden bg-surface-container-low mb-6 relative">
+				<img
+					className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-105"
+					alt={product.title}
+					src={image}
+				/>
+				<div className="absolute inset-0 bg-primary/5 opacity-0 group-hover:opacity-100 transition-opacity"></div>
+			</div>
+			<div className="space-y-2">
+				<div className="flex justify-between items-start">
+					<h3 className="font-headline text-xl text-on-surface leading-tight group-hover:text-primary transition-colors">
+						{product.title}
+					</h3>
+					<span className="font-label text-sm text-primary font-semibold">
+						${product.price.toLocaleString()}
+					</span>
+				</div>
+				<p className="font-body italic text-secondary">{product.author.name}</p>
+				<div className="flex items-center gap-3 pt-2">
+					<span className="font-label text-[10px] uppercase tracking-widest px-2 py-1 bg-surface-container-highest text-secondary">
+						{new Date(product.year).getFullYear()}
+					</span>
+					<span className="font-label text-[10px] uppercase tracking-widest px-2 py-1 bg-surface-container-highest text-secondary">
+						{product.condition.grade}
+					</span>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default ProductCard;

--- a/apps/webshop/src/lib/actions/products.ts
+++ b/apps/webshop/src/lib/actions/products.ts
@@ -1,0 +1,70 @@
+"use server";
+
+import type {
+	PaginatedResult,
+	ProductFilters,
+	ProductWithRelations,
+} from "@/app/types/prisma";
+import { prisma } from "@/lib/prisma";
+
+const productInclude = {
+	category: true,
+	condition: true,
+	author: true,
+	publisher: true,
+} as const;
+
+export async function getProducts(
+	filters: ProductFilters = {},
+): Promise<PaginatedResult<ProductWithRelations>> {
+	const {
+		page = 1,
+		pageSize = 12,
+		categoryId,
+		search,
+		sortBy = "title",
+		sortOrder = "asc",
+	} = filters;
+
+	const where: Record<string, unknown> = {};
+
+	if (categoryId) {
+		where.categoryId = categoryId;
+	}
+
+	if (search) {
+		where.OR = [
+			{ title: { contains: search, mode: "insensitive" } },
+			{ description: { contains: search, mode: "insensitive" } },
+			{ genre: { contains: search, mode: "insensitive" } },
+		];
+	}
+
+	const [data, total] = await Promise.all([
+		prisma.product.findMany({
+			where,
+			include: productInclude,
+			orderBy: { [sortBy]: sortOrder },
+			skip: (page - 1) * pageSize,
+			take: pageSize,
+		}),
+		prisma.product.count({ where }),
+	]);
+
+	return {
+		data,
+		total,
+		page,
+		pageSize,
+		totalPages: Math.ceil(total / pageSize),
+	};
+}
+
+export async function getProductById(
+	id: number,
+): Promise<ProductWithRelations | null> {
+	return prisma.product.findUnique({
+		where: { id },
+		include: productInclude,
+	});
+}

--- a/apps/webshop/src/lib/prisma.ts
+++ b/apps/webshop/src/lib/prisma.ts
@@ -1,0 +1,17 @@
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+	prisma: PrismaClient | undefined;
+};
+
+function createPrismaClient() {
+	const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL });
+	return new PrismaClient({ adapter });
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+	globalForPrisma.prisma = prisma;
+}


### PR DESCRIPTION
The server component in products.ts is a bit more complex than initially needed, but i prepared it for usage with pagination and such too.

**It also supports relations so it will actually grab an entire "ProductWithRelations" object**, containing all data needed - similar to how **MongoDB** data objects is.

We want to extract the product-grid to its own separate component i think, that has product-card within, but this is temporary for now - it works :)

Server components all the way, avoiding use client.

Closes #27 